### PR TITLE
Use proper API url to declare ServiceDiscovery

### DIFF
--- a/lib/rpc_servicedisco.js
+++ b/lib/rpc_servicedisco.js
@@ -42,7 +42,7 @@
 		// inherit from RPCWebinosService
 		this.base = RPCWebinosService;
 		this.base({
-			api: 'ServiceDiscovery',
+			api: 'http://webinos.org/internal/api/ServiceDiscovery',
 			displayName: 'ServiceDiscovery',
 			description: 'Webinos ServiceDiscovery'
 		});

--- a/wrt/webinos.servicedisco.js
+++ b/wrt/webinos.servicedisco.js
@@ -78,7 +78,9 @@
     /**
      * Interface DiscoveryInterface
      */
-    var ServiceDiscovery = function (rpcHandler) {
+    var ServiceDiscovery = function (obj, rpcHandler) {
+        WebinosService.call(this, obj);
+
         var _webinosReady = false;
         var callerCache = [];
 
@@ -93,7 +95,7 @@
             var that = this;
             var findOp;
             
-            var rpc = rpcHandler.createRPC('ServiceDiscovery', 'findServices',
+            var rpc = rpcHandler.createRPC(this, 'findServices',
                     [serviceType, options, filter]);
             
             var timer = setTimeout(function () {
@@ -220,6 +222,11 @@
         };
     }
 
-    webinos.discovery = new ServiceDiscovery (webinos.rpcHandler);
+    webinos.discovery = new ServiceDiscovery({
+            api: 'http://webinos.org/internal/api/ServiceDiscovery',
+            displayName: 'ServiceDiscovery',
+            description: 'Webinos ServiceDiscovery',
+            id: 'dfab7856f4ba55e3730c27c4e635a1d9'
+        }, webinos.rpcHandler);
     webinos.ServiceDiscovery = webinos.discovery; // for backward compat
 }());


### PR DESCRIPTION
By using a valid URL as API service type, the hard coded exceptions in
webinos-jsonrpc2 can be removed.

Jira-issue: http://jira.webinos.org/browse/WP-1044

Merge after: https://github.com/webinos/webinos-api-serviceDiscovery/pull/6
