### PR TITLE
Allow module to load

### DIFF
--- a/test/web_root/Placeholder.md
+++ b/test/web_root/Placeholder.md
@@ -1,0 +1,1 @@
+This is a placeholder as this folder is needed by webinos-utilities\lib\loadservice.js:245


### PR DESCRIPTION
Until webinos-utilities\lib\loadservice.js is fixed to ignore missing test bed folder.

Is this repository still in use?
